### PR TITLE
Use correct override signature for `MessageCodec.jsonArrayCodec`

### DIFF
--- a/rpc/shared/src/main/scala/kreuzberg/rpc/MessageCodec.scala
+++ b/rpc/shared/src/main/scala/kreuzberg/rpc/MessageCodec.scala
@@ -30,7 +30,7 @@ trait MessageCodec[T] {
 object MessageCodec {
   implicit val jsonArrayCodec: MessageCodec[String] = new MessageCodec[String] {
     import upickle.default._
-    override def combine(args: Seq[(String, String)]): String = {
+    override def combine(args: (String, String)*): String = {
       args.map(_._2).mkString("[", ",", "]")
     }
 


### PR DESCRIPTION
This PR fixes a compilation error found in Scala 3 Open Community Build for the improved checks of overriden signatures. 
Previously method taking a varargs could have been overriden with a method taking a `Seq`, it was an unintended bug. It was fixed in https://github.com/lampepfl/dotty/pull/16836 and would target Scala 3.4.0. It was the only public codebase which was using the no longer legal override. 

[Open CB logs](https://github.com/VirtusLab/community-build3/actions/runs/6985426387/job/19012218862)
We provide a fix for the broken compilation to allow for further testing of this project in the Open Community Build allowing us to find any other possible compiler regressions in the future.